### PR TITLE
Use long long integer type

### DIFF
--- a/stag_lib/CHANGELOG.md
+++ b/stag_lib/CHANGELOG.md
@@ -4,30 +4,36 @@ All notable changes to the library are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Changed
+- [Issue #27](https://github.com/staglibrary/stag/issues/27): Use `long long` integer type throughout the library
+
+### Added
+
 ## [0.2.0] - 2022-10-15
 ### Changed
-- [Issue #5](https://github.com/pmacg/stag/issues/5): Rename the `Graph::volume()` method to `Graph::total_volume()`
-- [Issue #5](https://github.com/pmacg/stag/issues/5): Attempting to construct a graph with an assymetric adjacency matrix
+- [Issue #5](https://github.com/staglibrary/stag/issues/5): Rename the `Graph::volume()` method to `Graph::total_volume()`
+- [Issue #5](https://github.com/staglibrary/stag/issues/5): Attempting to construct a graph with an assymetric adjacency matrix
 throws an exception
 - Sparse matrices within the library are now stored in Column-Major format
 
 ### Added
-- [Issue #5](https://github.com/pmacg/stag/issues/5): `Graph::degree_matrix()` method
-- [Issue #5](https://github.com/pmacg/stag/issues/5): `Graph::normalised_laplacian()` method
-- [Issue #5](https://github.com/pmacg/stag/issues/5): `Graph::number_of_vertices()` method
-- [Issue #5](https://github.com/pmacg/stag/issues/5): `Graph::number_of_edges()` method
-- [Issue #4](https://github.com/pmacg/stag/issues/4): Add `load_edgelist()` method to read graphs from edgelist files
-- [Issue #4](https://github.com/pmacg/stag/issues/4): Add `save_edgelist()` method to save graphs to edgelist files
+- [Issue #5](https://github.com/staglibrary/stag/issues/5): `Graph::degree_matrix()` method
+- [Issue #5](https://github.com/staglibrary/stag/issues/5): `Graph::normalised_laplacian()` method
+- [Issue #5](https://github.com/staglibrary/stag/issues/5): `Graph::number_of_vertices()` method
+- [Issue #5](https://github.com/staglibrary/stag/issues/5): `Graph::number_of_edges()` method
+- [Issue #4](https://github.com/staglibrary/stag/issues/4): Add `load_edgelist()` method to read graphs from edgelist files
+- [Issue #4](https://github.com/staglibrary/stag/issues/4): Add `save_edgelist()` method to save graphs to edgelist files
 - Add graph equality operators `==` and `!=`
-- [Issue #6](https://github.com/pmacg/stag/issues/6): Add `LocalGraph` abstract class for providing local graph access
-- [Issue #15](https://github.com/pmacg/stag/issues/15): Add methods for generating random graphs from the stochastic
+- [Issue #6](https://github.com/staglibrary/stag/issues/6): Add `LocalGraph` abstract class for providing local graph access
+- [Issue #15](https://github.com/staglibrary/stag/issues/15): Add methods for generating random graphs from the stochastic
 block model
 - New `inverse_degree_matrix()` method on the `stag::Graph` object
 - New `lazy_random_walk_matrix()` method on the `stag::Graph` object
-- [Issue #10](https://github.com/pmacg/stag/issues/10): Add approximate pagerank methods in `cluster.h`.
+- [Issue #10](https://github.com/staglibrary/stag/issues/10): Add approximate pagerank methods in `cluster.h`.
 - New `addVectors(v1, v2)` utility method
 - `barbell_graph(n)` graph constructor
-- [Issue #10](https://github.com/pmacg/stag/issues/10): Add ACL local clustering algorithm in `cluster.h`.
+- [Issue #10](https://github.com/staglibrary/stag/issues/10): Add ACL local clustering algorithm in `cluster.h`.
 
 ## [0.1.6] - 2022-10-10
 ### Added

--- a/stag_lib/graph.h
+++ b/stag_lib/graph.h
@@ -13,7 +13,7 @@
 
 // The fundamental datatype used in this library is the sparse matrix. For
 // convenience, we define the sparse matrix type here.
-#define stag_int Eigen::Index
+#define stag_int long long
 #define SprsMat Eigen::SparseMatrix<double, Eigen::ColMajor, stag_int>
 #define EdgeTriplet Eigen::Triplet<double, stag_int>
 
@@ -108,7 +108,7 @@ namespace stag {
        *
        * @return a sparse Eigen matrix representing the graph adjacency matrix.
        */
-      [[nodiscard]] const SprsMat* adjacency() const;
+      const SprsMat* adjacency() const;
 
       /**
        * Construct the Laplacian matrix of the graph.
@@ -179,7 +179,7 @@ namespace stag {
       /**
        * The number of vertices in the graph.
        */
-      [[nodiscard]] stag_int number_of_vertices() const;
+      stag_int number_of_vertices() const;
 
       /**
        * The number of edges in the graph.
@@ -187,7 +187,7 @@ namespace stag {
        * This is defined based on the number of non-zero elements in the
        * adjacency matrix, and ignores the weights of the edges.
        */
-       [[nodiscard]] stag_int number_of_edges() const;
+       stag_int number_of_edges() const;
 
        // Override the abstract methods in the LocalGraph base class.
        double degree(stag_int v) override;


### PR DESCRIPTION
Using a primitive type directly helps with interop with other languages.

Fixes #27 .